### PR TITLE
Added patch to filter permissions by folders

### DIFF
--- a/ding_permissions.make
+++ b/ding_permissions.make
@@ -10,6 +10,7 @@ projects[secure_permissions][download][type] = "git"
 projects[secure_permissions][download][url] = "http://git.drupal.org/project/secure_permissions.git"
 projects[secure_permissions][download][revision] = "ef5eec5"
 projects[secure_permissions][patch][] = "http://drupal.org/files/issues/2188491-features-multilingual-2.patch"
+projects[secure_permissions][patch][] = "http://drupal.org/files/issues/secure_permissions-filter_modules_permissions-2482565-1.patch"
 
 projects[role_delegation][subdir] = "contrib"
 projects[role_delegation][version] = "1.1"


### PR DESCRIPTION
This patch will add a feature to secure_permissions to choose which modules secure_permissions controls the permissions. I.e. now you can configure what permissions secure_permissions should control by the modules that define the permissions.

http://platform.dandigbib.org/issues/1188
