### PR TITLE
Enhancement #1188. New patch that modifies secure_permissions

### DIFF
--- a/ding_permissions.make
+++ b/ding_permissions.make
@@ -10,7 +10,7 @@ projects[secure_permissions][download][type] = "git"
 projects[secure_permissions][download][url] = "http://git.drupal.org/project/secure_permissions.git"
 projects[secure_permissions][download][revision] = "ef5eec5"
 projects[secure_permissions][patch][] = "http://drupal.org/files/issues/2188491-features-multilingual-2.patch"
-projects[secure_permissions][patch][] = "http://drupal.org/files/issues/secure_permissions-filter_modules_permissions-2482565-1.patch"
+projects[secure_permissions][patch][] = "http://drupal.org/files/issues/secure_permissions-dont_disable_all_permissions-2499607-1.patch"
 
 projects[role_delegation][subdir] = "contrib"
 projects[role_delegation][version] = "1.1"

--- a/ding_permissions.module
+++ b/ding_permissions.module
@@ -140,6 +140,9 @@ function ding_permissions_secure_permissions_roles() {
  */
 function ding_permissions_secure_permissions($role) {
   $permissions = array(
+    // Permissions to disable that aren't assigned to any roles.
+      0 => array(
+    ),
     'anonymous user' => array(
       'access comments',
       'access content',


### PR DESCRIPTION
http://platform.dandigbib.org/issues/1188

This patch makes it possible to configure, whether the module should disable no permissions, all permissions (like now), and only the permissions configured through hook_secure_permissions(). It also adds an option to define permissions we want to disable that aren't assigned to any role.

This way we can allow new modules to be installed without disabling its new permissions, even if the new permissions are generated through other modules (like node permissions).
