### PR TITLE
Issue #1188 by cableman: Added default configuration for the new secure permission patch

### DIFF
--- a/ding_permissions.install
+++ b/ding_permissions.install
@@ -8,10 +8,7 @@
  * Implements hook_install().
  */
 function ding_permissions_install() {
-  // Set folders for secure_permissions.
-  variable_set('secure_permissions_folders', "profiles/ding2/modules/*\nmodules/*");
-  // Set match type for secure_permissions.
-  variable_set('secure_permissions_type', 1);
+  variable_set('secure_permissions_disable_forms_settings', 2);
 }
 
 /**
@@ -27,4 +24,19 @@ function ding_permissions_update_7000() {
 function ding_permissions_update_7001() {
   variable_set('secure_permissions_folders', "profiles/ding2/modules/*\nmodules/*");
   variable_set('secure_permissions_type', 1);
+}
+
+/**
+ * Remove old configuration options.
+ */
+function ding_permissions_update_7002() {
+  variable_del('secure_permissions_type');
+  variable_del('secure_permissions_folders');
+}
+
+/**
+ * Set new configuration variables.
+ */
+function ding_permissions_update_7003() {
+  variable_set('secure_permissions_disable_forms_settings', 2);
 }


### PR DESCRIPTION
This patch ensure that configuration is set and permissions gets set during the installation process.

See http://platform.dandigbib.org/issues/1188
