### PR TITLE
Issue #460 by cableman: Added override_node_options module

### DIFF
--- a/ding_permissions.info
+++ b/ding_permissions.info
@@ -7,6 +7,7 @@ dependencies[] = ctools
 dependencies[] = secure_permissions
 dependencies[] = strongarm
 dependencies[] = role_delegation
+dependencies[] = override_node_options
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:1
 features[variable][] = secure_permissions_active

--- a/ding_permissions.install
+++ b/ding_permissions.install
@@ -40,3 +40,10 @@ function ding_permissions_update_7002() {
 function ding_permissions_update_7003() {
   variable_set('secure_permissions_disable_forms_settings', 2);
 }
+
+/**
+ * Enable override_node_options module
+ */
+function ding_permissions_update_7004() {
+  module_enable(array('override_node_options'));
+}

--- a/ding_permissions.make
+++ b/ding_permissions.make
@@ -14,3 +14,6 @@ projects[secure_permissions][patch][] = "http://drupal.org/files/issues/secure_p
 
 projects[role_delegation][subdir] = "contrib"
 projects[role_delegation][version] = "1.1"
+
+projects[override_node_options][subdir] = "contrib"
+projects[override_node_options][version] = "1.13"

--- a/ding_permissions.module
+++ b/ding_permissions.module
@@ -140,8 +140,9 @@ function ding_permissions_secure_permissions_roles() {
  */
 function ding_permissions_secure_permissions($role) {
   $permissions = array(
-    // Permissions to disable that aren't assigned to any roles.
-      0 => array(
+    // Permissions to disable even when no roles are assigned to them.
+    // You can use this to disable modification of permissions which is set to false for all roles.
+    0 => array(
     ),
     'anonymous user' => array(
       'access comments',
@@ -593,6 +594,13 @@ function ding_permissions_secure_permissions($role) {
       'manipulate all queues',
       'manipulate queues',
       'notify of path changes',
+      'override ding_event promote to front page option',
+      'override ding_event published option',
+      'override ding_group published option',
+      'override ding_news promote to front page option',
+      'override ding_news published option',
+      'override ding_page published option',
+      'override ding_rolltab published option',
       'participate in workflow',
       'revert revisions',
       'schedule (un)publishing of nodes',


### PR DESCRIPTION
Added module to allow better control over publishing and promotion options for nodes.

See http://platform.dandigbib.org/issues/460
